### PR TITLE
Existing toc detection too lax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ See [Keep a Changelog](http://keepachangelog.com/) for how this file is structur
 
 ## [Unreleased]
 
+## [Unreleased] - 2024-09-25
+
+Bugfixes:
+
+- Existing Table of Contents detection is too lax.
+
 ## [0.4.2] - 2024-09-24
 
 Added:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Locates all Level 2 headings in the currently selected markdown file and creates
 - Unsupported link-fragment characters are removed.
 - Headings that contain characters other than alpha-numerics will likely be processed with the exception of unsupported characters such as `<`, `>`, and `:`.
 - Use the VSCode Command Palette to insert the new table of contents.
+- If a Table of Contents already exists, the extension will not make any changes.
 
 See [CHANGELOG.md](./CHANGELOG.md) for details.
 
@@ -62,7 +63,7 @@ ActivationEvents: none.
 - Always use a Markdown Linter before running this tool for the best results.
 - A Level 1 Heading must be followed by a newline character or it will be ignored (note: Table of Contents generation does not depend on any Level 1 heading specifically).
 - Headings that start with a space may cause Create ToC to ignore the heading.
-- Skipped level 2 headings will not be shown in the generated Table of Contents.
+- Level 2 headings that do not match Level 1 heading style will not be shown in the generated Table of Contents.
 - Using multiple headings types will produce unexpected results.
 - A user can create a Heading with many spaces in it that will Lint without error. Create ToC will generate a valid, Linted Link Fragment for that "spacey heading" _but_ the link will be dead.
 
@@ -70,7 +71,7 @@ _Note_: See [GitHub Issues List](https://github.com/nojronatron/markdown-toc/iss
 
 ## Release Notes
 
-This release adds the ability to detect both Standard style and Alternate style level 1 and level 2 headings. In both cases, the generated Table of Contents anchors link fragments to the headings near the top of the existing markdown document.
+This release adds the ability to detect both Standard (Open ATX and Closed ATX) style and Alternate (Next Line) style level 1 and level 2 headings. In all cases, the generated Table of Contents with link fragments will be inserted near the top of the existing markdown document under the first discovered Level 1 heading.
 
 See [CHANGELOG.md](./CHANGELOG.md) for detailed release notes.
 

--- a/extension-functions/get-second-level-heading.js
+++ b/extension-functions/get-second-level-heading.js
@@ -20,16 +20,6 @@ function getSecondLevelHeading(firstLine, firstLineIdx, secondLine, isHash, isCl
   // clean title of all illegal characters
   let cleanedFirstLine = getTitleOnly(firstLine);
 
-  if (isTableOfContents(cleanedFirstLine)) {
-    return {
-      line: firstLineIdx,
-      text: cleanedFirstLine,
-      isHash: isHash,
-      isClosedAtx: isClosedAtx,
-      isToc: true,
-    };
-  }
-
   if (isHash) {
     return getHash2LH(firstLine, firstLineIdx, secondLine);
   }
@@ -46,16 +36,6 @@ function getSecondLevelHeading(firstLine, firstLineIdx, secondLine, isHash, isCl
     isClosedAtx: isClosedAtx, 
     isToc: false 
   };
-}
-
-/**
- * Check if the first line contains the text 'Table of Contents'.
- * @param {string} firstLine the text of the first line
- * @returns {boolean} true if the first line contains the text 'Table of Contents'
- */
-function isTableOfContents(firstLine) {
-  // if 'table of contents' is found the matcher returns an array, otherwise null
-  return firstLine.match(/^.*?(?:Table of Contents).*?$/) !== null;
 }
 
 /**

--- a/extension.js
+++ b/extension.js
@@ -38,6 +38,28 @@ function activate(context) {
           return null;
         }
 
+        // check if the document already has a TOC and warn the user if so
+        let hasTOC = false;
+
+        if (topHeading.isClosedAtx) {
+          // if matcher finds a Closed ATX style TOC set hasTOC to true
+          hasTOC = editor.document.getText().match(/^## Table of Contents ##$/m) !== null;
+        } else if (topHeading.isHash) {
+          // if matcher finds an Open ATX style TOC set hasTOC to true
+          hasTOC = editor.document.getText().match(/^## Table of Contents$/m) !== null;
+        } else {
+          // if matcher finds a dash style TOC set hasTOC to true
+          const docText = editor.document.getText();
+          // hasTOC = docText.match(/Table of Contents\n-+?/gm) !== null
+          // || docText.match(/Table of Contents\r\n-+?/gm) !== null;
+          hasTOC = docText.match(/(?:Table of Contents)(?:\n|\r\n)(?:-+?)/gm) !== null;
+        }
+
+        if (hasTOC) {
+          vscode.window.showWarningMessage('Table of Contents already exists.');
+          return null;
+        }
+        
         // Check if there is enough content to add a TOC
         if (editor.document.lineCount <= topHeading.line + 3) {
           vscode.window.showWarningMessage(
@@ -55,12 +77,6 @@ function activate(context) {
           let firstLine = editor.document.lineAt(idx-1).text;
           let secondLine = editor.document.lineAt(idx).text;
           const headingObject = getSecondLevelHeading(firstLine, idx-1, secondLine, topHeading.isHash, topHeading.isClosedAtx);
-
-          if (headingObject.isToc) {
-            // do no harm to existing document and allow user to make changes
-            vscode.window.showWarningMessage('Table of Contents already exists.');
-            return null;
-          }
           
           if (headingObject.line !== -1) {
             // add the heading object to the array if line is not -1

--- a/test/suite/getSecondLevelHeadings.test.js
+++ b/test/suite/getSecondLevelHeadings.test.js
@@ -258,5 +258,4 @@ suite('getDash2LH Function Tests', () => {
     assert.strictEqual(actual4.isHash, expected4.isHash);
     assert.strictEqual(actual4.isToc, expected4.isToc);
   });
-
 });


### PR DESCRIPTION
- [x] Bugfix: Detect only valid existing Table of Contents in current document.
- [x] Update README.
- [x] Update Changelog.
- [ ] Update tests.
